### PR TITLE
Fix post method signature

### DIFF
--- a/account_consolidation/models/account_move.py
+++ b/account_consolidation/models/account_move.py
@@ -35,11 +35,11 @@ class AccountMove(models.Model):
         return res
 
     @api.multi
-    def post(self):
+    def post(self, invoice=False):
         """Bypass move posting when reversing consolidation moves"""
         if self.env.context.get('__conso_reversal_no_post'):
             return True
-        return super().post()
+        return super().post(invoice=invoice)
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
account.move.post method is redefining core signature and thus breaking inheritance chains